### PR TITLE
feat: share pickpocket data with party or raid

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -6,6 +6,7 @@
 ------------------------------------------------------------
 PPT_ShowMsg              = (PPT_ShowMsg ~= nil) and PPT_ShowMsg or true
 PPT_Debug                = PPT_Debug or false
+PPT_ShareGroup           = (PPT_ShareGroup ~= nil) and PPT_ShareGroup or false
 PPT_TotalCopper          = tonumber(PPT_TotalCopper) or 0
 PPT_TotalAttempts        = tonumber(PPT_TotalAttempts) or 0
 PPT_SuccessfulAttempts   = tonumber(PPT_SuccessfulAttempts) or 0

--- a/Events.lua
+++ b/Events.lua
@@ -138,25 +138,35 @@ end)
 SLASH_PICKPOCKET1 = "/pp"
 SlashCmdList["PICKPOCKET"] = function(msg)
   msg = (msg or ""):lower()
-  if msg == "togglemsg" then
+  local cmd, arg = msg:match("^(%S+)%s*(.*)$")
+  if cmd == "togglemsg" then
     PPT_ShowMsg = not PPT_ShowMsg
     PPTPrint("showMsg =", tostring(PPT_ShowMsg)); return
-  elseif msg == "reset" then
+  elseif cmd == "share" then
+    if PPT_LastSummary then
+      ShareSessionSummary(true, PPT_LastSummary)
+    else
+      PPTPrint("No session summary to share yet")
+    end
+    return
+  elseif cmd == "auto" and arg == "share" then
+    PPT_ShareGroup = not PPT_ShareGroup
+    PPTPrint("auto share =", tostring(PPT_ShareGroup))
+    return
+  elseif cmd == "reset" then
     ResetAllStats()
     PPTPrint("Stats reset."); return
-  elseif msg == "debug" then
+  elseif cmd == "debug" then
     PPT_Debug = not PPT_Debug
     PPTPrint("debug =", tostring(PPT_Debug)); return
-  elseif msg == "items" then
+  elseif cmd == "items" then
     PPTPrint("Cumulative items:", PPT_TotalItems)
-    local list = {}
-    for name, cnt in pairs(PPT_ItemCounts) do table.insert(lines, string.format("%s x%d", name, cnt)) end
     local lines = {}
     for name, cnt in pairs(PPT_ItemCounts) do table.insert(lines, string.format("%s x%d", name, cnt)) end
     table.sort(lines, function(a,b) return a:lower() < b:lower() end)
     for _,ln in ipairs(lines) do PPTPrint(" ", ln) end
     return
-  elseif msg == "options" then
+  elseif cmd == "options" then
     -- Open options panel (Classic Era compatible)
     local panel = _G.RoguePickPocketTrackerOptions
     if panel then
@@ -194,6 +204,6 @@ SlashCmdList["PICKPOCKET"] = function(msg)
 
   PPTPrint("----- Totals -----");  PrintTotal()
   PPTPrint("----- Stats -----");   PrintStats()
-  PPTPrint("----- Help -----");    PPTPrint("Usage: /pp [togglemsg, reset, debug, items, options]")
+  PPTPrint("----- Help -----");    PPTPrint("Usage: /pp [togglemsg, share, auto share, reset, debug, items, options]")
 end
 

--- a/Events.lua
+++ b/Events.lua
@@ -143,11 +143,7 @@ SlashCmdList["PICKPOCKET"] = function(msg)
     PPT_ShowMsg = not PPT_ShowMsg
     PPTPrint("showMsg =", tostring(PPT_ShowMsg)); return
   elseif cmd == "share" then
-    if PPT_LastSummary then
-      ShareSessionSummary(true, PPT_LastSummary)
-    else
-      PPTPrint("No session summary to share yet")
-    end
+    ShareSummaryAndStats(true, PPT_LastSummary)
     return
   elseif cmd == "auto" and arg == "share" then
     PPT_ShareGroup = not PPT_ShareGroup

--- a/Options.lua
+++ b/Options.lua
@@ -20,7 +20,7 @@ panel.showMsg:SetScript("OnClick", function(self) PPT_ShowMsg = self:GetChecked(
 
 panel.shareGroup = CreateFrame("CheckButton", "PPT_ShareGroupCheck", panel, "InterfaceOptionsCheckButtonTemplate")
 panel.shareGroup:SetPoint("TOPLEFT", panel.showMsg, "BOTTOMLEFT", 0, -8)
-panel.shareGroup.Text:SetText("Share data with group")
+panel.shareGroup.Text:SetText("Auto share stats")
 panel.shareGroup:SetScript("OnClick", function(self) PPT_ShareGroup = self:GetChecked() end)
 
 -- Reset statistics button

--- a/Options.lua
+++ b/Options.lua
@@ -18,10 +18,15 @@ panel.showMsg:SetPoint("TOPLEFT", title, "BOTTOMLEFT", 0, -8)
 panel.showMsg.Text:SetText("Show loot messages")
 panel.showMsg:SetScript("OnClick", function(self) PPT_ShowMsg = self:GetChecked() end)
 
+panel.shareGroup = CreateFrame("CheckButton", "PPT_ShareGroupCheck", panel, "InterfaceOptionsCheckButtonTemplate")
+panel.shareGroup:SetPoint("TOPLEFT", panel.showMsg, "BOTTOMLEFT", 0, -8)
+panel.shareGroup.Text:SetText("Share data with group")
+panel.shareGroup:SetScript("OnClick", function(self) PPT_ShareGroup = self:GetChecked() end)
+
 -- Reset statistics button
 panel.resetBtn = CreateFrame("Button", nil, panel, "UIPanelButtonTemplate")
 panel.resetBtn:SetSize(140, 22)
-panel.resetBtn:SetPoint("TOPLEFT", panel.showMsg, "BOTTOMLEFT", 0, -10)
+panel.resetBtn:SetPoint("TOPLEFT", panel.shareGroup, "BOTTOMLEFT", 0, -10)
 panel.resetBtn:SetText("Reset Statistics")
 panel.resetBtn:SetScript("OnClick", function()
   ResetAllStats()
@@ -57,6 +62,7 @@ panel.statAvgSuccess:SetPoint("TOPLEFT", panel.statAvgAttempt, "BOTTOMLEFT", 0, 
 -- Refresh stats display
 function panel:updateStats()
   self.showMsg:SetChecked(PPT_ShowMsg)
+  self.shareGroup:SetChecked(PPT_ShareGroup)
   self.statCoin:SetText("Total Coinage: "..coinsToString(PPT_TotalCopper))
   self.statItems:SetText("Total Items: "..PPT_TotalItems)
   self.statAttempts:SetText("Attempts: "..PPT_TotalAttempts)

--- a/README.md
+++ b/README.md
@@ -10,15 +10,15 @@ A World of Warcraft Classic addon that tracks pickpocketing statistics and loot 
 - Provides detailed statistics and averages
 - Options panel for configuration
 - Slash commands for quick access
-- Optionally shares pickpocket results with your party or raid, manually or automatically
+- Optionally shares total stats and your last session summary to your last chat channel, manually or automatically
 
 ## Slash Commands
 
 - `/pp` - Show statistics and help
 - `/pp options` - Open the options panel
 - `/pp togglemsg` - Toggle loot messages
-- `/pp share` - Share the most recent session summary once
-- `/pp auto share` - Toggle sharing data with your group
+- `/pp share` - Share totals and the most recent session summary
+- `/pp auto share` - Toggle automatic sharing
 - `/pp reset` - Reset all statistics
 - `/pp debug` - Toggle debug mode
 - `/pp items` - Show cumulative item counts
@@ -103,7 +103,7 @@ A World of Warcraft addon that tracks pickpocketing statistics for Rogue charact
 - **Item Tracking**: Records all items looted during pickpocketing sessions
 - **Session Reports**: Provides detailed reports after each stealth session
 - **Persistent Data**: All statistics are saved between game sessions
-- **Group Sharing**: Optionally broadcast session results to your party or raid
+- **Group Sharing**: Optionally broadcast your totals and last session summary to your last chat channel
 
 ## Installation
 
@@ -127,8 +127,8 @@ Use `/pp` to access the following commands:
 
 - `/pp` - Display current statistics and totals
 - `/pp togglemsg` - Toggle pickup messages on/off
-- `/pp share` - Share the most recent session summary once
-- `/pp auto share` - Toggle sharing data with your group
+- `/pp share` - Share totals and the most recent session summary
+- `/pp auto share` - Toggle automatic sharing
 - `/pp reset` - Reset all statistics to zero
 - `/pp debug` - Toggle debug mode for troubleshooting
 - `/pp items` - Display all items collected from pickpocketing

--- a/README.md
+++ b/README.md
@@ -10,12 +10,15 @@ A World of Warcraft Classic addon that tracks pickpocketing statistics and loot 
 - Provides detailed statistics and averages
 - Options panel for configuration
 - Slash commands for quick access
+- Optionally shares pickpocket results with your party or raid, manually or automatically
 
 ## Slash Commands
 
 - `/pp` - Show statistics and help
 - `/pp options` - Open the options panel
 - `/pp togglemsg` - Toggle loot messages
+- `/pp share` - Share the most recent session summary once
+- `/pp auto share` - Toggle sharing data with your group
 - `/pp reset` - Reset all statistics
 - `/pp debug` - Toggle debug mode
 - `/pp items` - Show cumulative item counts
@@ -100,6 +103,7 @@ A World of Warcraft addon that tracks pickpocketing statistics for Rogue charact
 - **Item Tracking**: Records all items looted during pickpocketing sessions
 - **Session Reports**: Provides detailed reports after each stealth session
 - **Persistent Data**: All statistics are saved between game sessions
+- **Group Sharing**: Optionally broadcast session results to your party or raid
 
 ## Installation
 
@@ -123,6 +127,8 @@ Use `/pp` to access the following commands:
 
 - `/pp` - Display current statistics and totals
 - `/pp togglemsg` - Toggle pickup messages on/off
+- `/pp share` - Share the most recent session summary once
+- `/pp auto share` - Toggle sharing data with your group
 - `/pp reset` - Reset all statistics to zero
 - `/pp debug` - Toggle debug mode for troubleshooting
 - `/pp items` - Display all items collected from pickpocketing

--- a/RoguePickPocketTracker.toc
+++ b/RoguePickPocketTracker.toc
@@ -3,7 +3,7 @@
 ## Notes: Keeps track of total money looted from pickpocketing.
 ## Author: Wurby
 ## Version: @project-version@
-## SavedVariables: PPT_ShowMsg, PPT_Debug, PPT_TotalCopper, PPT_TotalAttempts, PPT_SuccessfulAttempts, PPT_TotalItems, PPT_ItemCounts
+## SavedVariables: PPT_ShowMsg, PPT_Debug, PPT_ShareGroup, PPT_TotalCopper, PPT_TotalAttempts, PPT_SuccessfulAttempts, PPT_TotalItems, PPT_ItemCounts
 
 Core.lua
 Session.lua

--- a/Session.lua
+++ b/Session.lua
@@ -125,7 +125,8 @@ function ShareSummaryAndStats(force, summary)
   local ch, target = getLastChatTarget()
   if not ch then return end
   for _,m in ipairs(buildShareMessages(summary or PPT_LastSummary)) do
-    SendChatMessage(m, ch, nil, target)
+    -- "|" must be escaped as "||" to avoid item-link parsing in chat
+    SendChatMessage(m:gsub("|", "||"), ch, nil, target)
   end
 end
 


### PR DESCRIPTION
## Summary
- add optional group sharing for session summaries
- expose sharing toggle via `/pp auto share` and options panel
- document new feature and saved variable
- allow manual one-time sharing of the most recent session using `/pp share`

## Testing
- `luacheck .` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `apt-get install -y luacheck` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a11dacb8e083279806bdd8950af07c