### PR TITLE
feat: add achievement tracking

### DIFF
--- a/Achievements.lua
+++ b/Achievements.lua
@@ -1,0 +1,153 @@
+-- Achievements.lua
+-- Achievement tracking for RoguePickPocketTracker
+
+-- Initialize saved variable table
+PPT_Achievements = type(PPT_Achievements) == "table" and PPT_Achievements or {}
+
+-- Achievement catalog
+Achievements = {
+  PICKPOCKET_100 = {
+    id = 1,
+    name = "Cutpurse",
+    description = "Pick pocket 100 targets",
+    goal = 100,
+    progress = 0,
+  },
+  PICKPOCKET_1K = {
+    id = 2,
+    name = "Master Thief",
+    description = "Pick pocket 1000 targets",
+    goal = 1000,
+    progress = 0,
+  },
+  PICKPOCKET_5K = {
+    id = 3,
+    name = "Grand Larcenist",
+    description = "Pick pocket 5000 targets",
+    goal = 5000,
+    progress = 0,
+  },
+  EARN_25G_SESSION = {
+    id = 4,
+    name = "Big Haul",
+    description = "Loot 25 gold in a single session",
+    goal = 2500,
+    progress = 0,
+  },
+  EARN_100G_SESSION = {
+    id = 5,
+    name = "Massive Haul",
+    description = "Loot 100 gold in a single session",
+    goal = 10000,
+    progress = 0,
+  },
+  LOOT_1_ITEM_SESSION = {
+    id = 6,
+    name = "Ooh, Piece of Candy",
+    description = "Loot 1 item in a single session",
+    goal = 1,
+    progress = 0,
+  },
+  LOOT_2_ITEMS_SESSION = {
+    id = 7,
+    name = "You don't need this, right?",
+    description = "Loot 2 items in a single session",
+    goal = 2,
+    progress = 0,
+  },
+  LOOT_5_ITEMS_SESSION = {
+    id = 8,
+    name = "Thanks, Obama.",
+    description = "Loot 5 items in a single session",
+    goal = 5,
+    progress = 0,
+  },
+  LOOT_10_ITEMS_SESSION = {
+    id = 9,
+    name = "My backpack is full",
+    description = "Loot 10 items in a single session",
+    goal = 10,
+    progress = 0,
+  },
+  SESSION_TARGETS_1 = {
+    id = 10,
+    name = "Noob",
+    description = "Pick pocket 1 target in a single session",
+    goal = 1,
+    progress = 0,
+  },
+  SESSION_TARGETS_3 = {
+    id = 11,
+    name = "Amateur",
+    description = "Pick pocket 3 targets in a single session",
+    goal = 3,
+    progress = 0,
+  },
+  SESSION_TARGETS_5 = {
+    id = 12,
+    name = "Professional",
+    description = "Pick pocket 5 targets in a single session",
+    goal = 5,
+    progress = 0,
+  },
+  SESSION_TARGETS_10 = {
+    id = 13,
+    name = "Ninja",
+    description = "Pick pocket 10 targets in a single session",
+    goal = 10,
+    progress = 0,
+  },
+  SESSION_TARGETS_15 = {
+    id = 14,
+    name = "Was that my shadow?",
+    description = "Pick pocket 15 targets in a single session",
+    goal = 15,
+    progress = 0,
+  },
+}
+
+-- Load saved progress
+for id, ach in pairs(Achievements) do
+  local saved = PPT_Achievements[id]
+  if type(saved) == "table" then
+    ach.progress = saved.progress or ach.progress
+    ach.completed = saved.completed or false
+  end
+end
+
+local function persist(id)
+  local ach = Achievements[id]
+  if not ach then return end
+  PPT_Achievements[id] = {
+    progress = ach.progress,
+    completed = ach.completed,
+  }
+end
+
+function Celebrate(id)
+  local ach = Achievements[id]
+  if not ach then return end
+  PPTPrint("Achievement Unlocked:", ach.name)
+  PlaySound(12889)
+end
+
+function UpdateAchievement(id, value)
+  local ach = Achievements[id]
+  if not ach or ach.completed then return end
+
+  ach.progress = (ach.progress or 0) + (value or 0)
+  if ach.progress >= ach.goal then
+    ach.completed = true
+  end
+
+  persist(id)
+  if ach.completed then Celebrate(id) end
+end
+
+function GetAchievementProgressText(ach)
+  if ach.completed then
+    return "|cff00ff00Completed|r"
+  end
+  return string.format("%d/%d", ach.progress or 0, ach.goal)
+end
+

--- a/Events.lua
+++ b/Events.lua
@@ -64,7 +64,7 @@ frame:SetScript("OnEvent", function(_, event, ...)
     end
 
   elseif event == "COMBAT_LOG_EVENT_UNFILTERED" then
-    local _, sub, _, srcGUID, _, _, _, dstGUID, _, _, _, spellID = CombatLogGetCurrentEventInfo()
+    local _, sub, _, srcGUID, _, _, _, dstGUID, dstName, _, _, spellID = CombatLogGetCurrentEventInfo()
     if not playerGUID then return end
 
     if dstGUID == playerGUID and STEALTH_IDS[spellID] then
@@ -80,7 +80,13 @@ frame:SetScript("OnEvent", function(_, event, ...)
       sessionHadPick = true
       if dstGUID and not attemptedGUIDs[dstGUID] then
         attemptedGUIDs[dstGUID] = true
+        sessionTargetCount = sessionTargetCount + 1
         PPT_TotalAttempts = PPT_TotalAttempts + 1
+        if UpdateAchievement then
+          UpdateAchievement("PICKPOCKET_100", 1)
+          UpdateAchievement("PICKPOCKET_1K", 1)
+          UpdateAchievement("PICKPOCKET_5K", 1)
+        end
         DebugPrint("Pick: attempt recorded for %s", tostring(dstGUID))
       else
         DebugPrint("Pick: duplicate attempt ignored")
@@ -156,6 +162,36 @@ SlashCmdList["PICKPOCKET"] = function(msg)
     table.sort(lines, function(a,b) return a:lower() < b:lower() end)
     for _,ln in ipairs(lines) do PPTPrint(" ", ln) end
     return
+  elseif msg == "achievements" then
+    local panel = _G.RoguePickPocketTrackerOptions
+    if panel then
+      if InterfaceOptionsFrame_OpenToCategory then
+        InterfaceOptionsFrame_OpenToCategory(panel)
+      elseif InterfaceOptionsFrame_OpenToPanel then
+        InterfaceOptionsFrame_OpenToPanel(panel)
+      elseif Settings and Settings.OpenToCategory then
+        if _G.PPT_SettingsCategory then
+          Settings.OpenToCategory(_G.PPT_SettingsCategory)
+        elseif panel.settingsCategory then
+          Settings.OpenToCategory(panel.settingsCategory)
+        else
+          SettingsPanel:Open()
+        end
+      else
+        if InterfaceOptionsFrame then
+          InterfaceOptionsFrame:Show()
+          panel:SetParent(InterfaceOptionsFramePanelContainer)
+          panel:Show()
+        elseif SettingsPanel then
+          SettingsPanel:Open()
+          panel:Show()
+        end
+      end
+      PPTPrint("Opening achievements panel...")
+    else
+      PPTPrint("Error: Options panel not found!")
+    end
+    return
   elseif msg == "options" then
     -- Open options panel (Classic Era compatible)
     local panel = _G.RoguePickPocketTrackerOptions
@@ -194,6 +230,6 @@ SlashCmdList["PICKPOCKET"] = function(msg)
 
   PPTPrint("----- Totals -----");  PrintTotal()
   PPTPrint("----- Stats -----");   PrintStats()
-  PPTPrint("----- Help -----");    PPTPrint("Usage: /pp [togglemsg, reset, debug, items, options]")
+  PPTPrint("----- Help -----");    PPTPrint("Usage: /pp [togglemsg, reset, debug, items, achievements, options]")
 end
 

--- a/Options.lua
+++ b/Options.lua
@@ -54,6 +54,15 @@ panel.statAvgAttempt:SetPoint("TOPLEFT", panel.statFails, "BOTTOMLEFT", 0, -10)
 panel.statAvgSuccess = panel:CreateFontString(nil, "ARTWORK", "GameFontHighlight")
 panel.statAvgSuccess:SetPoint("TOPLEFT", panel.statAvgAttempt, "BOTTOMLEFT", 0, -4)
 
+panel.achHeader = panel:CreateFontString(nil, "ARTWORK", "GameFontNormal")
+panel.achHeader:SetPoint("TOPLEFT", panel.statAvgSuccess, "BOTTOMLEFT", 0, -20)
+panel.achHeader:SetText("Achievements:")
+
+panel.achText = panel:CreateFontString(nil, "ARTWORK", "GameFontHighlight")
+panel.achText:SetPoint("TOPLEFT", panel.achHeader, "BOTTOMLEFT", 0, -4)
+panel.achText:SetJustifyH("LEFT")
+panel.achText:SetWidth(300)
+
 -- Refresh stats display
 function panel:updateStats()
   self.showMsg:SetChecked(PPT_ShowMsg)
@@ -68,7 +77,19 @@ function panel:updateStats()
   self.statAvgSuccess:SetText("Avg/Success: "..coinsToString(avgSuccess))
 end
 
-panel:SetScript("OnShow", function(self) self:updateStats() end)
+function panel:updateAchievements()
+  local lines = {}
+  for _,ach in pairs(Achievements) do
+    table.insert(lines, string.format("%s - %s", ach.name, GetAchievementProgressText(ach)))
+  end
+  table.sort(lines)
+  self.achText:SetText(table.concat(lines, "\n"))
+end
+
+panel:SetScript("OnShow", function(self)
+  self:updateStats()
+  if self.updateAchievements then self:updateAchievements() end
+end)
 
 -- Make panel globally accessible
 _G.RoguePickPocketTrackerOptions = panel

--- a/RoguePickPocketTracker.toc
+++ b/RoguePickPocketTracker.toc
@@ -3,9 +3,10 @@
 ## Notes: Keeps track of total money looted from pickpocketing.
 ## Author: Wurby
 ## Version: @project-version@
-## SavedVariables: PPT_ShowMsg, PPT_Debug, PPT_TotalCopper, PPT_TotalAttempts, PPT_SuccessfulAttempts, PPT_TotalItems, PPT_ItemCounts
+## SavedVariables: PPT_ShowMsg, PPT_Debug, PPT_TotalCopper, PPT_TotalAttempts, PPT_SuccessfulAttempts, PPT_TotalItems, PPT_ItemCounts, PPT_Achievements
 
 Core.lua
+Achievements.lua
 Session.lua
 Events.lua
 Options.lua

--- a/Session.lua
+++ b/Session.lua
@@ -13,6 +13,7 @@ sessionCopper = 0
 mirroredCopperThisSession = 0
 sessionHadPick = false
 attemptedGUIDs = {}      -- one attempt per target per session
+sessionTargetCount = 0
 sessionItemsCount = 0
 sessionItems = {}
 
@@ -79,6 +80,7 @@ function resetSession()
   sessionCopper = 0
   mirroredCopperThisSession = 0
   sessionHadPick = false
+  sessionTargetCount = 0
   sessionItemsCount = 0
   sessionItems = {}
   attemptedGUIDs = {}
@@ -106,6 +108,37 @@ function finalizeSession(reasonIfZero)
       PPT_SuccessfulAttempts = PPT_SuccessfulAttempts + 1
       DebugPrint("Finalize: +%s, items %d", coinsToString(sessionCopper), sessionItemsCount)
       PrintSessionSummary()
+      if Achievements then
+        if Achievements.EARN_25G_SESSION and sessionCopper >= Achievements.EARN_25G_SESSION.goal then
+          UpdateAchievement("EARN_25G_SESSION", sessionCopper)
+        end
+        if Achievements.EARN_100G_SESSION and sessionCopper >= Achievements.EARN_100G_SESSION.goal then
+          UpdateAchievement("EARN_100G_SESSION", sessionCopper)
+        end
+        local itemAch = {
+          "LOOT_1_ITEM_SESSION",
+          "LOOT_2_ITEMS_SESSION",
+          "LOOT_5_ITEMS_SESSION",
+          "LOOT_10_ITEMS_SESSION",
+        }
+        for _, id in ipairs(itemAch) do
+          if Achievements[id] and sessionItemsCount >= Achievements[id].goal then
+            UpdateAchievement(id, sessionItemsCount)
+          end
+        end
+        local targetAch = {
+          "SESSION_TARGETS_1",
+          "SESSION_TARGETS_3",
+          "SESSION_TARGETS_5",
+          "SESSION_TARGETS_10",
+          "SESSION_TARGETS_15",
+        }
+        for _, id in ipairs(targetAch) do
+          if Achievements[id] and sessionTargetCount >= Achievements[id].goal then
+            UpdateAchievement(id, sessionTargetCount)
+          end
+        end
+      end
     else
       DebugPrint("Finalize: no loot (%s)", reasonIfZero or "no change")
       PrintNoCoin(reasonIfZero or "no change")


### PR DESCRIPTION
## Summary
- add persistent achievement catalog and progress tracking
- integrate achievements with event handling and session summaries
- expose achievement progress in options panel and `/pp achievements` command
- expand catalog with early pickpocket, session gold, item milestones, and per-session target counts

## Testing
- `luac -p Achievements.lua Core.lua Session.lua Events.lua Options.lua` *(fails: command not found)*
- `apt-get update` *(403  Forbidden [IP: 172.30.1.51 8080])*
- `apt-get install -y lua5.4` *(Unable to locate package lua5.4)*

------
https://chatgpt.com/codex/tasks/task_e_68a11ec19668832795e9f09599cf4e10